### PR TITLE
Update to support key collectiviteOutremer

### DIFF
--- a/build/communes.js
+++ b/build/communes.js
@@ -30,6 +30,9 @@ async function buildCommunes() {
         codesPostaux: commune.codesPostaux || [],
         population: commune.population
       }
+      if ('collectiviteOutremer' in commune) {
+        communeData['collectiviteOutremer'] = commune['collectiviteOutremer']
+      }
 
       if (commune.code in communesFeaturesIndex) {
         const contour = communesFeaturesIndex[commune.code].geometry

--- a/lib/communeHelpers.js
+++ b/lib/communeHelpers.js
@@ -1,7 +1,7 @@
 const {initFields, initFormat} = require('./helpers')
 
 const initCommuneFields = initFields({
-  default: ['nom', 'code', 'codeDepartement', 'codeRegion', 'codesPostaux', 'population'],
+  default: ['nom', 'code', 'codeDepartement', 'codeRegion', 'codesPostaux', 'population', 'collectiviteOutremer'],
   base: ['nom', 'code']
 })
 

--- a/lib/communes.js
+++ b/lib/communes.js
@@ -19,6 +19,11 @@ const schema = {
   code: {type: 'token', queryWith: 'code'},
   codesPostaux: {type: 'tokenList', queryWith: 'codePostal'},
   codeDepartement: {type: 'token', queryWith: 'codeDepartement'},
+  collectiviteOutremer: {
+    type: 'tokenNested',
+    queryWith: 'collectiviteOutremer',
+    nestedKey: 'code'
+  },
   codeRegion: {type: 'token', queryWith: 'codeRegion'},
   contour: {type: 'geo', queryWith: 'pointInContour'}
 }

--- a/lib/searchableCollection/index.js
+++ b/lib/searchableCollection/index.js
@@ -6,6 +6,7 @@ const TextIndex = require('./indexes/text')
 const createIndexByType = {
   token: (key, params) => new TokenIndex(key, params),
   tokenList: (key, params) => new TokenIndex(key, {...params, array: true}),
+  tokenNested: (key, params) => new TokenIndex(key, params),
   text: (key, params) => new TextIndex(key, params),
   geo: key => new GeoIndex(key)
 }

--- a/lib/searchableCollection/indexes/token.js
+++ b/lib/searchableCollection/indexes/token.js
@@ -8,6 +8,7 @@ class TokenIndex {
 
     this._key = key
     this._array = options.array || false
+    this._nestedKey = options.nestedKey || false
     this._multiple = options.multiple
     this._index = new Map()
   }
@@ -24,6 +25,8 @@ class TokenIndex {
     if (this._key in item) {
       if (this._array) {
         item[this._key].forEach(token => this.indexForToken(token, item))
+      } else if (this._nestedKey) {
+        this.indexForToken(item[this._key][this._nestedKey], item)
       } else {
         this.indexForToken(item[this._key], item)
       }

--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ app.use((req, res, next) => {
 
 /* Communes */
 app.get('/communes', initLimit(), initCommuneFields, initCommuneFormat, (req, res) => {
-  const query = pick(req.query, 'type', 'code', 'codePostal', 'nom', 'codeDepartement', 'codeRegion', 'boost')
+  const query = pick(req.query, 'type', 'code', 'codePostal', 'nom', 'collectiviteOutremer', 'codeDepartement', 'codeRegion', 'boost')
   if (req.query.lat && req.query.lon) {
     const lat = parseFloat(req.query.lat)
     const lon = parseFloat(req.query.lon)


### PR DESCRIPTION
Pour résoudre #154, le choix est de pouvoir filtrer par code de COM

- Exemple pour lister toutes les communes d'un COM http://localhost:5000/communes?collectiviteOutremer=987
- Exemple similaire mais ajout du filtre `codePostal` http://localhost:5000/communes?collectiviteOutremer=987&codePostal=98745

Ce qui m'ennuie est que d'un côté je veux pouvoir lister toutes les collectivités d'Outre-Mer et d'autre part, je ne suis pas fan de détourner le endpoint département pour ce besoin. Par ailleurs, il peut être intéressant d'avoir l'étendue de la COM.