### PR TITLE
Update for COG 2023

### DIFF
--- a/build/communes-associees-deleguees.js
+++ b/build/communes-associees-deleguees.js
@@ -11,7 +11,10 @@ const {readGeoJSONFeatures, writeData, fixPrecision} = require('./util')
 
 const resolution = process.env.BUILD_LOW_RESOLUTION === '1' ? '50m' : '5m'
 
-const COMMUNES_ASSOCIEES_DELEGUEES_FEATURES_PATH = join(__dirname, '..', 'data', `communes-associees-deleguees-${resolution}.geojson.gz`)
+let COMMUNES_ASSOCIEES_DELEGUEES_FEATURES_PATH = ''
+if (process.env.COMMUNES_ASSOCIEES_DELEGUEES) {
+  COMMUNES_ASSOCIEES_DELEGUEES_FEATURES_PATH = join(__dirname, '..', 'data', `communes-associees-deleguees-${resolution}.geojson.gz`)
+}
 
 const COMMUNES_EPCI_MATCHING = epci.reduce((acc, curr) => {
   curr.membres.forEach(membre => {
@@ -22,8 +25,11 @@ const COMMUNES_EPCI_MATCHING = epci.reduce((acc, curr) => {
 }, {})
 
 async function buildCommunesAssocieesDeleguees() {
-  const communesAssocieesDelegueesFeatures = await readGeoJSONFeatures(COMMUNES_ASSOCIEES_DELEGUEES_FEATURES_PATH)
-  const communesAssocieesDelegueesFeaturesIndex = keyBy(communesAssocieesDelegueesFeatures, f => f.properties.code)
+  let communesAssocieesDelegueesFeaturesIndex = {}
+  if (COMMUNES_ASSOCIEES_DELEGUEES_FEATURES_PATH) {
+    const communesAssocieesDelegueesFeatures = await readGeoJSONFeatures(COMMUNES_ASSOCIEES_DELEGUEES_FEATURES_PATH)
+    communesAssocieesDelegueesFeaturesIndex = keyBy(communesAssocieesDelegueesFeatures, f => f.properties.code)
+  }
 
   const communesAssocieesDelegueesData = communes
     .filter(commune => {

--- a/build/communes.js
+++ b/build/communes.js
@@ -12,7 +12,7 @@ const {readGeoJSONFeatures, writeData, fixPrecision} = require('./util')
 const resolution = process.env.BUILD_LOW_RESOLUTION === '1' ? '50m' : '5m'
 
 const COMMUNES_FEATURES_PATH = join(__dirname, '..', 'data', `communes-${resolution}.geojson.gz`)
-const COMMUNES_FEATURES_MAIRIE_PATH = join(__dirname, '..', 'data', 'chflieux-communes-arrondissements-municipaux.geojson.gz')
+const COMMUNES_FEATURES_MAIRIE_PATH = join(__dirname, '..', 'data', 'mairies.geojson.gz')
 
 const MORTES_POUR_LA_FRANCE = ['55189', '55039', '55050', '55239', '55307', '55139']
 
@@ -52,7 +52,7 @@ async function buildCommunes() {
   const communesFeatures = await readGeoJSONFeatures(COMMUNES_FEATURES_PATH)
   const communesFeaturesIndex = keyBy(communesFeatures, f => f.properties.code)
   const communesFeaturesMairie = await readGeoJSONFeatures(COMMUNES_FEATURES_MAIRIE_PATH)
-  const communesFeaturesMairieIndex = keyBy(communesFeaturesMairie, f => f.properties.insee_com)
+  const communesFeaturesMairieIndex = keyBy(communesFeaturesMairie, f => f.properties.commune)
 
   const communesData = communes
     .filter(commune => {

--- a/download-sources.sh
+++ b/download-sources.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
+YEAR=${YEAR:-2023}
+COMMUNES_ASSOCIEES_DELEGUEES=${COMMUNES_ASSOCIEES_DELEGUEES:-NO}
 echo "Create data directory"
 mkdir -p data
 echo "Retrieve datasets"
-wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/communes-5m.geojson.gz
-wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/communes-50m.geojson.gz
-wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/communes-associees-deleguees-5m.geojson.gz
-wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/communes-associees-deleguees-50m.geojson.gz
-wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/chflieux-communes-arrondissements-municipaux.geojson.gz
-wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/epci-5m.geojson.gz
-wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/epci-50m.geojson.gz
+wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/${YEAR}/geojson/communes-5m.geojson.gz
+wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/${YEAR}/geojson/communes-50m.geojson.gz
+if [ "$COMMUNES_ASSOCIEES_DELEGUEES" != "NO" ]; then
+    wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/${YEAR}/geojson/communes-associees-deleguees-5m.geojson.gz
+    wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/${YEAR}/geojson/communes-associees-deleguees-50m.geojson.gz
+fi
+wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/${YEAR}/geojson/mairies.geojson.gz
+wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/${YEAR}/geojson/epci-5m.geojson.gz
+wget -N -P data/ http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/${YEAR}/geojson/epci-50m.geojson.gz
 echo "Completed"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "rbush": "^2.0.1"
   },
   "devDependencies": {
-    "@etalab/decoupage-administratif": "^2.3.1",
+    "@etalab/decoupage-administratif": "^3.0.0",
     "@turf/area": "^6.0.1",
     "@turf/bbox": "^6.5.0",
     "@turf/bbox-polygon": "^6.5.0",

--- a/server.js
+++ b/server.js
@@ -55,55 +55,57 @@ app.use((req, res, next) => {
   next()
 })
 
-/* Communes associées et déléguées */
-app.get('/communes_associees_deleguees', initLimit(), initCommunesAssocieeDelegueeFields, initCommuneAssocieeDelegueeFormat, (req, res) => {
-  const query = pick(req.query, 'type', 'code', 'nom', 'codeEpci', 'codeDepartement', 'codeRegion')
-  if (req.query.lat && req.query.lon) {
-    const lat = parseFloat(req.query.lat)
-    const lon = parseFloat(req.query.lon)
-    if (Number.isFinite(lat) &&
-      lat >= -90 &&
-      lat <= 90 &&
-      Number.isFinite(lon) &&
-      lon >= -180 &&
-      lon <= 180
-    ) {
-      query.pointInContour = [lon, lat]
+if (process.env.COMMUNES_ASSOCIEES_DELEGUEES) {
+  /* Communes associées et déléguées */
+  app.get('/communes_associees_deleguees', initLimit(), initCommunesAssocieeDelegueeFields, initCommuneAssocieeDelegueeFormat, (req, res) => {
+    const query = pick(req.query, 'type', 'code', 'nom', 'codeEpci', 'codeDepartement', 'codeRegion')
+    if (req.query.lat && req.query.lon) {
+      const lat = parseFloat(req.query.lat)
+      const lon = parseFloat(req.query.lon)
+      if (Number.isFinite(lat) &&
+        lat >= -90 &&
+        lat <= 90 &&
+        Number.isFinite(lon) &&
+        lon >= -180 &&
+        lon <= 180
+      ) {
+        query.pointInContour = [lon, lat]
+      }
     }
-  }
 
-  if (query.nom) {
-    req.fields.add('_score')
-  }
+    if (query.nom) {
+      req.fields.add('_score')
+    }
 
-  if (Object.keys(query).length === 0 && (req.outputFormat === 'geojson' || req.fields.has('contour'))) {
-    return res.sendStatus(400)
-  }
+    if (Object.keys(query).length === 0 && (req.outputFormat === 'geojson' || req.fields.has('contour'))) {
+      return res.sendStatus(400)
+    }
 
-  if (query.type) {
-    query.type = query.type.split(',')
-  }
+    if (query.type) {
+      query.type = query.type.split(',')
+    }
 
-  const result = req.applyLimit(dbCommunesAssocieesDeleguees.search({...communesAssocieesDelegueesDefaultQuery, ...query}))
+    const result = req.applyLimit(dbCommunesAssocieesDeleguees.search({...communesAssocieesDelegueesDefaultQuery, ...query}))
 
-  if (req.outputFormat === 'geojson') {
-    res.send({
-      type: 'FeatureCollection',
-      features: result.map(commune => formatOne(req, commune))
-    })
-  } else {
-    res.send(result.map(commune => formatOne(req, commune)))
-  }
-})
+    if (req.outputFormat === 'geojson') {
+      res.send({
+        type: 'FeatureCollection',
+        features: result.map(commune => formatOne(req, commune))
+      })
+    } else {
+      res.send(result.map(commune => formatOne(req, commune)))
+    }
+  })
 
-app.get('/communes_associees_deleguees/:code', initCommunesAssocieeDelegueeFields, initCommuneAssocieeDelegueeFormat, (req, res) => {
-  const communes = dbCommunesAssocieesDeleguees.search({code: req.params.code})
-  if (communes.length === 0) {
-    res.sendStatus(404)
-  } else {
-    res.send(formatOne(req, communes[0]))
-  }
-})
+  app.get('/communes_associees_deleguees/:code', initCommunesAssocieeDelegueeFields, initCommuneAssocieeDelegueeFormat, (req, res) => {
+    const communes = dbCommunesAssocieesDeleguees.search({code: req.params.code})
+    if (communes.length === 0) {
+      res.sendStatus(404)
+    } else {
+      res.send(formatOne(req, communes[0]))
+    }
+  })
+}
 
 /* Communes */
 app.get('/communes', initLimit(), initCommuneFields, initCommuneFormat, (req, res) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,10 +90,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@etalab/decoupage-administratif@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-2.3.1.tgz#9d8c4606407ceef062c1bcde3aa57be31d661fdc"
-  integrity sha512-52zR447e9Csr/HkzmLJIrOTCAuwJNd4O9fay8BRgOQUSbqaKOP6vFpsrj5lKlrH9vA+ii07h1TnChdMFZNgcwg==
+"@etalab/decoupage-administratif@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-3.0.0.tgz#1d0d54b5b884c3df9555b4b8db543f83559629d3"
+  integrity sha512-WlXHeArXK7zwcxoPev8NM3ncUjaIiBYiTmY1wh3X6RXITKjTwn3yaYdQqbPplTfFA/ByllG4Y4q4Jt0bCmbEzw==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
- MAJ de la dépendance @etalab/decoupage-administratif pour le COG 2023
- Utilisation de la variable COMMUNES_ASSOCIEES_DELEGUEES pour activer le endpoint /communes_associees_deleguees (mais les communes associées/déleguées sont bien listées dans l'API endpoint). Cette variable est aussi utilisée dans le téléchargement des contours administratifs 2023 (dérivé principalement de Admin Express COG 2023)
- Remplacement du nom de la ressource distante chflieux-communes-arrondissements-municipaux.geojson.gz par mairies.geojson.gz avec changement du nom de colonne de `insee_com` à `commune`