### PR TITLE
Support code INSEE parent for arrondissements

### DIFF
--- a/build/communes.js
+++ b/build/communes.js
@@ -16,6 +16,8 @@ const COMMUNES_FEATURES_MAIRIE_PATH = join(__dirname, '..', 'data', 'mairies.geo
 
 const MORTES_POUR_LA_FRANCE = ['55189', '55039', '55050', '55239', '55307', '55139']
 
+const COMMUNES_AVEC_ARRONDISSEMENTS = ['13055', '69123', '75056']
+
 const COMMUNES_EPCI_MATCHING = epci.reduce((acc, curr) => {
   curr.membres.forEach(membre => {
     acc[membre.code] = curr.code
@@ -69,6 +71,10 @@ async function buildCommunes() {
         codesPostaux: [...(commune.codesPostaux || [])].sort(),
         population: commune.population,
         zone: commune.zone
+      }
+
+      if (commune.type === 'arrondissement-municipal' && COMMUNES_AVEC_ARRONDISSEMENTS.map(com => com.slice(0, 2)).includes(commune.departement)) {
+        communeData.codeParent = COMMUNES_AVEC_ARRONDISSEMENTS.find(el => el.slice(0, 2) === commune.departement)
       }
 
       if (commune.code in COMMUNES_EPCI_MATCHING) {

--- a/definition.yml
+++ b/definition.yml
@@ -18,6 +18,7 @@ parameters:
       enum:
         - nom
         - code
+        - codeParent
         - codesPostaux
         - siren
         - centre
@@ -248,6 +249,10 @@ paths:
         - name: codeRegion
           in: query
           description: Code de la région associée
+          type: string
+        - name: codeParent
+          in: query
+          description: Code de la commune si on a un arrondissement
           type: string
         - $ref: '#/parameters/zoneParam'
         - $ref: '#/parameters/typeCommune'

--- a/lib/communes.js
+++ b/lib/communes.js
@@ -17,6 +17,7 @@ const schema = {
   },
   type: {type: 'token', queryWith: 'type', multiple: 'OR'},
   code: {type: 'token', queryWith: 'code'},
+  codeParent: {type: 'token', queryWith: 'codeParent'},
   codesPostaux: {type: 'tokenList', queryWith: 'codePostal'},
   siren: {type: 'token', queryWith: 'siren'},
   codeEpci: {type: 'token', queryWith: 'codeEpci'},

--- a/server.js
+++ b/server.js
@@ -111,7 +111,7 @@ if (process.env.COMMUNES_ASSOCIEES_DELEGUEES) {
 
 /* Communes */
 app.get('/communes', initLimit(), initCommuneFields, initCommuneFormat, (req, res) => {
-  const query = pick(req.query, 'type', 'code', 'codePostal', 'nom', 'siren', 'deleguees', 'associees', 'codeEpci', 'codeDepartement', 'codeRegion', 'boost', 'zone')
+  const query = pick(req.query, 'type', 'code', 'codePostal', 'nom', 'siren', 'deleguees', 'associees', 'codeEpci', 'codeDepartement', 'codeRegion', 'boost', 'zone', 'codeParent')
   if (req.query.lat && req.query.lon) {
     const lat = parseFloat(req.query.lat)
     const lon = parseFloat(req.query.lon)


### PR DESCRIPTION
L'intérêt de l'évolution

Pour retourner le code de la commune parente d'un arrondissement
<http://localhost:5000/communes?type=arrondissement-municipal&lat=48.866667&lon=2.333333&fields=nom,code,codeDepartement,codeRegion,codesPostaux,population,codeParent>

Pour filtrer depuis le code INSEE de la commune, les arrondissements
<http://localhost:5000/communes?type=arrondissement-municipal&fields=nom,code,codeDepartement,codeRegion,codesPostaux,population,codeParent&codeParent=75056>