### PR TITLE
Support HEAD requests

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -92,12 +92,12 @@ function formatOne(req, target) {
   return properties
 }
 
-const allowOnlyGet = (req, res, next) => {
-  if (req.method !== 'GET') {
+const allowOnlyGetAndHead = (req, res, next) => {
+  if (!(['GET', 'HEAD'].includes(req.method))) {
     return res.status(401).send(`Method ${req.method} not allowed`)
   }
 
   next()
 }
 
-module.exports = {initLimit, initFields, initFormat, formatOne, allowOnlyGet}
+module.exports = {initLimit, initFields, initFormat, formatOne, allowOnlyGetAndHead}

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const {initCommunesAssocieeDelegueeFields, initCommuneAssocieeDelegueeFormat, co
 const {initEpciFields, initEpciFormat, epciDefaultQuery} = require('./lib/epciHelpers')
 const {initDepartementFields, departementsDefaultQuery} = require('./lib/departementHelpers')
 const {initRegionFields, regionsDefaultQuery} = require('./lib/regionHelpers')
-const {formatOne, initLimit, allowOnlyGet} = require('./lib/helpers')
+const {formatOne, initLimit, allowOnlyGetAndHead} = require('./lib/helpers')
 const dbCommunes = require('./lib/communes').getIndexedDb()
 const dbCommunesAssocieesDeleguees = require('./lib/communesAssocieesDeleguees').getIndexedDb()
 const dbEpci = require('./lib/epcis').getIndexedDb()
@@ -43,7 +43,7 @@ if (process.env.SENTRY_DSN) {
   app.use(Sentry.Handlers.tracingHandler())
 }
 
-app.use(allowOnlyGet)
+app.use(allowOnlyGetAndHead)
 
 // Inject databases references
 app.use((req, res, next) => {


### PR DESCRIPTION
Some tools need to do a HEAD request before doing any GET requests like DuckDB.
The PR solves the issue