### PR TITLE
To fix error for split fields

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,9 @@
 const {pick, take} = require('lodash')
 
+function isString(value) {
+  return typeof value === 'string'
+}
+
 function initFields(options = {}) {
   if (!options.default || !options.base) {
     throw new Error('Options default and base are required')
@@ -7,7 +11,13 @@ function initFields(options = {}) {
 
   return (req, res, next) => {
     if (req.query.fields) {
-      req.fields = new Set(req.query.fields.split(','))
+      if (isString(req.query.fields)) {
+        req.fields = new Set(req.query.fields.split(','))
+      } else if (Array.isArray(req.query.fields)) {
+        req.fields = new Set(req.query.fields)
+      } else {
+        req.fields = new Set(options.default)
+      }
     } else {
       req.fields = new Set(options.default)
     }


### PR DESCRIPTION
Due to error "req.query.fields.split is not a function", we check if string and not only if `fields` exists in params query.
We also check if array and manage it e.g when people do https://geo.api.gouv.fr/communes?fields=code&fields=nom&nom=Landerneau